### PR TITLE
calculating ord which is the reverse permutation for reordering betas back to the original X matrix

### DIFF
--- a/R/DMR4glm.R
+++ b/R/DMR4glm.R
@@ -147,16 +147,13 @@ DMR4glm <- function(X, y, clust.method, lam){
    m$coef[is.na(m$coef)] <- min_value / 1000.0 #setting a very small (close to 0) value for the variables exceeding design matrix rank
                             #consult the comment in part2beta_help() for longer explanation
 
-   b = cbind(b, c(m$coef, rep(0, length(heig) - 1)))
-   zb = exp(m$coef*rep(1, length(y)))
-   pix = zb/(zb + 1)
-   loglik = c(loglik, sum(log(pix)[y == 1]) + sum(log(1-pix)[y == 0]))
-   if(length(ord) > 0){
-                  ind <- c(1:p)
-                  ind[-ord] = 1:(p - length(ord))
-                  ind[ord] = (p - length(ord) + 1):p
-                  b = b[ind,]
-   }
+   b <- cbind(b, c(m$coef, rep(0, length(heig) - 1)))
+   zb <- exp(m$coef*rep(1, length(y)))
+   pix <- zb/(zb + 1)
+   loglik <- c(loglik, sum(log(pix)[y == 1]) + sum(log(1-pix)[y == 0]))
+
+   b <- b[ord,]  #reordering betas to reflect the original matrix X
+
    fit <- list(beta = b, df = p:1, loglik = loglik, n = n, levels.listed = levels.listed, lambda=numeric(0), arguments = list(family = "binomial", clust.method = clust.method, lam = lam), interc = TRUE)
    class(fit) = "DMR"
    return(fit)

--- a/R/DMR4lm.R
+++ b/R/DMR4lm.R
@@ -143,14 +143,11 @@ DMR4lm <- function(X, y, clust.method, lam){
    m$coef[is.na(m$coef)] <- min_value / 1000.0 #setting a very small (close to 0) value for the variables exceeding design matrix rank
                     #consult the comment in part2beta_help() for longer explanation
 
-   b = cbind(b, c(m$coef, rep(0, length(heig) - 1)))
-   rss = c(rss, sum(m$res^2))
-   if(length(ord) > 0){
-                  ind <- c(1:p)
-                  ind[-ord] = 1:(p - length(ord))
-                  ind[ord] = (p - length(ord) + 1):p
-                  b = b[ind,]
-   }
+   b <- cbind(b, c(m$coef, rep(0, length(heig) - 1)))
+   rss <- c(rss, sum(m$res^2))
+
+   b <- b[ord,]  #reordering betas to reflect the original matrix X
+
    fit <- list(beta = b, df = p:1, rss = rss, n = n, levels.listed = levels.listed, lambda=numeric(0), arguments = list(family = "binomial", clust.method = clust.method), interc = TRUE)
    class(fit) = "DMR"
    return(fit)

--- a/R/prelasso_common.R
+++ b/R/prelasso_common.R
@@ -31,16 +31,10 @@ prelasso_common <- function(X, y, nn) {
   n.cont <- length(cont)
   names.cont <- names(nn)[cont]
 
-  ord <- c()
-  if(n.cont > 0 ){
-    if(n.factors > 0){
-      for (j in 1:n.cont){
-        ord[j] <- sum(n.levels[1:sum(nn[1:cont[j]] == "factor")] - 1) + j + 1
-      }
-    } else{
-      ord <- 2:(n.cont + 1)
-    }
-  }
+  fl <- c(n.levels, rep(2, n.cont))
+  ord <- c(1, order(rep(order(nn), fl-1))+1)   # this is a reverse permutation for reshuffling betas in the end in wrap_up()
+                                    # including the Intercept
+                                    #the reason fl is applied AFTER the first order is that fl is calculated for ordered columns
 
   X <- X[, order(nn), drop = FALSE]  # for DMR it is important that it happens early on, before factor_columns is computed
                                      # OR: compute factor_columsn once more
@@ -49,7 +43,7 @@ prelasso_common <- function(X, y, nn) {
 
   x.full <- stats::model.matrix(y~., data = data.frame(y=y, X, check.names = TRUE))
   p <- ncol(x.full)   # sum over all dimensions of X, e.g. for a factor with k levels it is taking (k-1) as a summand
-  fl <- c(n.levels, rep(2, n.cont))
+
   x.full_normalized <- apply(x.full, 2, function(x) sqrt(n/sum(x^2))*x)
 
   groups <- rep(1:p.x, fl-1)

--- a/R/wrap_up_binomial.R
+++ b/R/wrap_up_binomial.R
@@ -30,12 +30,9 @@ wrap_up_binomial <- function(mm, p, maxp, SS, fl, x.full, ord, n, levels.listed,
   })
 
   rownames(be) <- colnames(x.full)
-  if(length(ord) > 0){
-    ind1 <- c(1:p)
-    ind1[-ord] = 1:(p - length(ord))
-    ind1[ord] = (p - length(ord) + 1):p
-    be = be[ind1,]
-  }
+
+  be <- be[ord,]  #reordering betas to reflect the original matrix X
+
   fit <- list(beta = be, df = length(idx):1, loglik = loglik[cbind(idx, ind[idx])], n = n, levels.listed = levels.listed, lambda = mL$lambda, arguments=arguments, interc = TRUE)
   class(fit) = "DMR"
   return(fit)

--- a/R/wrap_up_gaussian.R
+++ b/R/wrap_up_gaussian.R
@@ -31,12 +31,8 @@ wrap_up_gaussian <- function(mm, p, maxp, SS, fl, X, y, x.full, ord, n, levels.l
   })
 
   rownames(be) <- colnames(x.full)
-  if(length(ord) > 0){
-    ind1 <- c(1:p)
-    ind1[-ord] = 1:(p - length(ord))
-    ind1[ord] = (p - length(ord) + 1):p
-    be = be[ind1,]
-  }
+
+  be <- be[ord,]  #reordering betas to reflect the original matrix X
 
   fit <- list(beta = be, df = length(idx):1, rss = rss[cbind(idx, ind[idx])], n = n, levels.listed = levels.listed, lambda = mL$lambda, arguments = arguments, interc = TRUE)
 


### PR DESCRIPTION
Old code for `ord` which I couldn't understand was dropped